### PR TITLE
Atualizando client para adicionar os campos PublishedAfter e PublishedBefore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thehive/cms-content-api",
-  "version": "0.6.11",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thehive/cms-content-api",
-      "version": "0.6.11",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thehive/cms-content-api",
-  "version": "0.6.11",
+  "version": "0.7.0",
   "description": "HTTP Client for The Hive CMS Content API",
   "main": "dist/index.js",
   "repository": {

--- a/src/clients/posts/types/get-posts-page-query.ts
+++ b/src/clients/posts/types/get-posts-page-query.ts
@@ -9,4 +9,6 @@ export type GetPostsPageQuery = Pagination & {
   titleContains?: string
   includeData?: boolean
   orderBy?: 'MostViewed'
+  PublishedAfter?: Date
+  PublishedBefore?: Date
 }


### PR DESCRIPTION
- Atualizando o client para adicionar os campos PublishedAfter e PublishedBefore no tipo `GetPostsPageQuery`
- Atualizando a versão do pacote (0.6.11 -> 0.7.0)